### PR TITLE
Improve tracing and debug logging for LAVA jobs

### DIFF
--- a/cros/helpers/mcu.py
+++ b/cros/helpers/mcu.py
@@ -178,8 +178,9 @@ def mcu_hello(s, name):
                   msg=f"Wrong EC HELLO magic number ({response.out_data})")
 
 def mcu_get_version(name):
-    if os.path.exists("/dev/" + name):
-        fd = open("/dev/" + name, "r")
+    devpath = os.path.join("/dev", name)
+    if os.path.exists(devpath):
+        fd = open(devpath, "r")
 
         response = ec_response_get_version()
 
@@ -197,7 +198,7 @@ def mcu_get_version(name):
             return response
 
 def mcu_reboot(name):
-    fd = open("/dev/" + name, "r")
+    fd = open(os.path.join("/dev", name), "r")
     cmd = cros_ec_command()
     cmd.version = 0
     cmd.command = EC_CMD_REBOOT

--- a/cros/helpers/mcu.py
+++ b/cros/helpers/mcu.py
@@ -141,8 +141,8 @@ def check_mcu_abi(s, name):
     """ Checks that the MCU character device exists in /dev and then verifies
         the standard MCU ABI in /sys/class/chromeos.
     """
-    if not os.path.exists("/dev/" + name):
-        s.skipTest("MCU " + name + " not supported, skipping")
+    if not os.path.exists(os.path.join("/dev", name)):
+        s.skipTest(f"MCU {name} not supported")
     files = ["flashinfo", "reboot", "version"]
     sysfs_check_attributes_exists(
         s, "/sys/class/chromeos/", name, files, False
@@ -151,9 +151,10 @@ def check_mcu_abi(s, name):
 
 def mcu_hello(s, name):
     """ Checks basic comunication with MCU. """
-    if not os.path.exists("/dev/" + name):
-        s.skipTest("MCU " + name + " not present, skipping")
-    fd = open("/dev/" + name, "r")
+    devpath = os.path.join("/dev", name)
+    if not os.path.exists(devpath):
+        s.skipTest(f"MCU {name} not present")
+    fd = open(devpath, "r")
     param = ec_params_hello()
     param.in_data = 0xA0B0C0D0  # magic number that the EC expects on HELLO
 
@@ -171,9 +172,10 @@ def mcu_hello(s, name):
 
     fd.close()
 
-    s.assertEqual(cmd.result, 0)
+    s.assertEqual(cmd.result, 0, msg="Error sending EC HELLO")
     # magic number that the EC answers on HELLO
-    s.assertEqual(response.out_data, 0xA1B2C3D4)
+    s.assertEqual(response.out_data, 0xA1B2C3D4,
+                  msg=f"Wrong EC HELLO magic number ({response.out_data})")
 
 def mcu_get_version(name):
     if os.path.exists("/dev/" + name):
@@ -208,9 +210,10 @@ def mcu_reboot(name):
     fd.close()
 
 def check_mcu_reboot_rw(s, name):
-    if not os.path.exists("/dev/" + name):
-        s.skipTest("cros_fp not present, skipping")
+    if not os.path.exists(os.path.join("/dev", name)):
+        s.skipTest("cros_fp not present")
     mcu_reboot(name)
     response = mcu_get_version(name)
-    s.assertEqual(response.current_image, EC_IMAGE_RW)
+    s.assertEqual(response.current_image, EC_IMAGE_RW,
+                  msg="Current EC image is not RW")
 

--- a/cros/helpers/sysfs.py
+++ b/cros/helpers/sysfs.py
@@ -31,8 +31,9 @@ def sysfs_check_attributes_exists(s, path, name, files, check_devtype):
                     continue
             match += 1
             for filename in files:
-                s.assertEqual(os.path.exists(path + "/" + devname + "/" + filename), 1)
+                p = os.path.join(path, devname, filename)
+                s.assertTrue(os.path.exists(p), msg=f"{p} not found")
     except IOError as e:
-            self.skipTest("Exception occured: {0}, skipping".format(e.strerror))
+        s.skipTest(f"{e}")
     if match == 0:
-        s.skipTest("No " + name + " found, skipping")
+        s.skipTest(f"No {name} found")

--- a/cros/helpers/sysfs.py
+++ b/cros/helpers/sysfs.py
@@ -21,7 +21,7 @@ def sysfs_check_attributes_exists(s, path, name, files, check_devtype):
     try:
         for devname in os.listdir(path):
             if check_devtype:
-                fd = open(path + "/" + devname + "/name", "r")
+                fd = open(os.path.join(path, devname, 'name'), "r")
                 devtype = fd.read()
                 fd.close()
                 if not devtype.startswith(name):

--- a/cros/runners/lava_runner.py
+++ b/cros/runners/lava_runner.py
@@ -3,6 +3,7 @@
 
 import sys
 import unittest
+import traceback
 
 from cros.tests.cros_ec_accel import *
 from cros.tests.cros_ec_gyro import *
@@ -14,37 +15,59 @@ from cros.tests.cros_ec_extcon import *
 
 
 class LavaTextTestResult(unittest.TestResult):
-    def __init__(self, runner):
-        unittest.TestResult.__init__(self)
+    def __init__(self, runner, verbosity=0):
+        super().__init__()
+        self.trace_on = verbosity > 0
+        self.debug_on = verbosity > 1
         self.runner = runner
 
     def addSuccess(self, test):
-        unittest.TestResult.addSuccess(self, test)
+        super().addSuccess(test)
+        testcase = test.id().rsplit(".")[-1]
         self.runner.writeUpdate(
-            "<LAVA_SIGNAL_TESTCASE TEST_CASE_ID=%s RESULT=pass>\n"
-            % test.id().rsplit(".")[-1]
-        )
+            f"<LAVA_SIGNAL_TESTCASE TEST_CASE_ID={testcase} RESULT=pass>\n")
 
     def addError(self, test, err):
-        unittest.TestResult.addError(self, test, err)
+        super().addError(test, err)
+        testcase = test.id().rsplit(".")[-1]
+        if self.trace_on:
+            exc_type, exc_value, exc_tb = err
+            msg = str(exc_value).split(' : ')
+            if len(msg) > 1:
+                msg = ''.join(msg[1:])
+            else:
+                msg = msg[0]
+            self.runner.writeUpdate(f"{testcase} ERROR: {msg}\n")
+        if self.debug_on:
+            exc_type, exc_value, exc_tb = err
+            traceback.print_tb(exc_tb, file=self.runner.stream)
         self.runner.writeUpdate(
-            "<LAVA_SIGNAL_TESTCASE TEST_CASE_ID=%s RESULT=unknown>\n"
-            % test.id().rsplit(".")[-1]
-        )
+            f"<LAVA_SIGNAL_TESTCASE TEST_CASE_ID={testcase} RESULT=unknown>\n")
 
     def addFailure(self, test, err):
-        unittest.TestResult.addFailure(self, test, err)
+        super().addFailure(test, err)
+        testcase = test.id().rsplit(".")[-1]
+        if self.trace_on:
+            exc_type, exc_value, exc_tb = err
+            msg = str(exc_value).split(' : ')
+            if len(msg) > 1:
+                msg = ''.join(msg[1:])
+            else:
+                msg = msg[0]
+            self.runner.writeUpdate(f"{testcase} FAIL: {msg}\n")
+        if self.debug_on:
+            exc_type, exc_value, exc_tb = err
+            traceback.print_tb(exc_tb, file=self.runner.stream)
         self.runner.writeUpdate(
-            "<LAVA_SIGNAL_TESTCASE TEST_CASE_ID=%s RESULT=fail>\n"
-            % test.id().rsplit(".")[-1]
-        )
+            f"<LAVA_SIGNAL_TESTCASE TEST_CASE_ID={testcase} RESULT=fail>\n")
 
     def addSkip(self, test, reason):
-        unittest.TestResult.addSkip(self, test, reason)
+        super().addSkip(test, reason)
+        testcase = test.id().rsplit(".")[-1]
+        if self.trace_on:
+            self.runner.writeUpdate(f"{testcase} SKIP: {reason}\n")
         self.runner.writeUpdate(
-            "<LAVA_SIGNAL_TESTCASE TEST_CASE_ID=%s RESULT=skip>\n"
-            % test.id().rsplit(".")[-1]
-        )
+            f"<LAVA_SIGNAL_TESTCASE TEST_CASE_ID={testcase} RESULT=skip>\n")
 
 
 class LavaTestRunner:
@@ -56,15 +79,29 @@ class LavaTestRunner:
         self.stream.write(message)
 
     def run(self, test):
-        result = LavaTextTestResult(self)
+        result = LavaTextTestResult(self, self.verbosity)
         test(result)
         result.testsRun
         return result
 
 
 if __name__ == "__main__":
+    verbosity = 0
+    # Parse additional "verbosity" parameter and strip it from sys.argv
+    # so that unittest can do the rest of the command line parsing
+    if '--verbosity' in sys.argv:
+        i = sys.argv.index('--verbosity')
+        try:
+            verbosity = int(sys.argv[i+1])
+            sys.argv.pop(i+1)
+        except IndexError:
+            pass
+        except ValueError:
+            sys.argv.pop(i+1)
+        finally:
+            sys.argv.pop(i)
     unittest.main(
-        testRunner=LavaTestRunner(),
+        testRunner=LavaTestRunner(verbosity=verbosity),
         # these make sure that some options that are not applicable
         # remain hidden from the help menu.
         failfast=False,

--- a/cros/tests/cros_ec_accel.py
+++ b/cros/tests/cros_ec_accel.py
@@ -71,10 +71,12 @@ class TestCrosECAccel(unittest.TestCase):
                         value *= accel_scale
                         mag += value * value
                     mag = math.sqrt(mag)
-                    self.assertTrue(abs(mag - exp) <= err)
+                    self.assertTrue(abs(mag - exp) <= err,
+                                    msg=f("Incorrect accelerometer data "
+                                          "in {dev_basepath} ({abs(mag - exp)})"))
                     match += 1
                 fd.close()
         except IOError as e:
-            self.skipTest("Exception occured: {0}, skipping".format(e.strerror))
+            self.skipTest(f"Exception occured: {e.strerror}")
         if match == 0:
-            self.skipTest("No accelerometer found, skipping")
+            self.skipTest("No accelerometer found")

--- a/cros/tests/cros_ec_accel.py
+++ b/cros/tests/cros_ec_accel.py
@@ -6,7 +6,7 @@ from cros.helpers.mcu import *
 from cros.helpers.sysfs import *
 import math
 import unittest
-
+import os
 
 class TestCrosECAccel(unittest.TestCase):
     def test_cros_ec_accel_iio_abi(self):
@@ -55,18 +55,21 @@ class TestCrosECAccel(unittest.TestCase):
         ACCEL_MAG_VALID_OFFSET = 0.25
         match = 0
         try:
-            for devname in os.listdir("/sys/bus/iio/devices"):
-                base_path = "/sys/bus/iio/devices/" + devname + "/"
-                fd = open(base_path + "name", "r")
+            basepath = "/sys/bus/iio/devices"
+            for devname in os.listdir(basepath):
+                dev_basepath = os.path.join(basepath, devname)
+                fd = open(os.path.join(dev_basepath, "name"), "r")
                 devtype = fd.read()
                 if devtype.startswith("cros-ec-accel"):
-                    location = read_file(base_path + "location")
-                    accel_scale = float(read_file(base_path + "scale"))
+                    location = read_file(os.path.join(dev_basepath, "location"))
+                    accel_scale = float(read_file(os.path.join(dev_basepath, "scale")))
                     exp = ACCEL_1G_IN_MS2
                     err = exp * ACCEL_MAG_VALID_OFFSET
                     mag = 0
-                    for axis in ["x", "y", "z"]:
-                        axis_path = base_path + "in_accel_" + axis + "_raw"
+                    for axis in ["in_accel_x_raw",
+                                 "in_accel_y_raw",
+                                 "in_accel_z_raw"]:
+                        axis_path = os.path.join(dev_basepath, axis)
                         value = int(read_file(axis_path))
                         value *= accel_scale
                         mag += value * value

--- a/cros/tests/cros_ec_extcon.py
+++ b/cros/tests/cros_ec_extcon.py
@@ -3,35 +3,28 @@
 
 from cros.helpers.sysfs import *
 import unittest
-
+import os
 
 class TestCrosECextcon(unittest.TestCase):
     def test_cros_ec_extcon_usbc_abi(self):
         """ Checks the cros-ec extcon ABI. """
         match = 0
         try:
-            for devname in os.listdir("/sys/class/extcon"):
-                devtype = read_file("/sys/class/extcon/" + devname + "/name")
+            basepath = "/sys/class/extcon"
+            for devname in os.listdir(basepath):
+                dev_basepath = os.path.join(basepath, devname)
+                devtype = read_file(os.path.join(dev_basepath, "name"))
                 if ".spi:ec@0:extcon@" in devtype:
-                    self.assertEqual(
-                        os.path.exists("/sys/class/extcon/" + devname + "/state"), 1
-                    )
-                    for cable in os.listdir("/sys/class/extcon/" + devname):
+                    p = os.path.join(dev_basepath, "state")
+                    self.assertTrue(os.path.exists(p), msg=f"{p} not found")
+                    for cable in os.listdir(dev_basepath):
                         if cable.startswith("cable"):
-                            self.assertEqual(
-                                os.path.exists(
-                                    "/sys/class/extcon/" + devname + "/" + cable + "/name"
-                                ),
-                                1,
-                            )
-                            self.assertEqual(
-                                os.path.exists(
-                                    "/sys/class/extcon/" + devname + "/" + cable + "/state"
-                                ),
-                                1,
-                            )
+                            p = os.path.join(dev_basepath, cable, "name")
+                            self.assertTrue(os.path.exists(p), msg=f"{p} not found")
+                            p = os.path.join(dev_basepath, cable, "state")
+                            self.assertTrue(os.path.exists(p), msg=f"{p} not found")
                             match += 1
         except IOError as e:
-            self.skipTest("Exception occured: {0}, skipping".format(e.strerror))
+            self.skipTest(f"{e}")
         if match == 0:
-            self.skipTest("No extcon device found, skipping")
+            self.skipTest("No extcon device found")

--- a/cros/tests/cros_ec_mcu.py
+++ b/cros/tests/cros_ec_mcu.py
@@ -25,7 +25,8 @@ class TestCrosECMCU(unittest.TestCase):
 
     def test_cros_ec_chardev(self):
         """ Checks the main Embedded controller character device. """
-        self.assertEqual(os.path.exists("/dev/cros_ec"), 1)
+        self.assertTrue(os.path.exists("/dev/cros_ec"),
+                        msg="/dev/ec not found")
 
     def test_cros_ec_hello(self):
         """ Checks basic comunication with the main Embedded controller. """

--- a/cros/tests/cros_ec_rtc.py
+++ b/cros/tests/cros_ec_rtc.py
@@ -4,7 +4,7 @@
 from cros.helpers.mcu import *
 from cros.helpers.sysfs import *
 import unittest
-
+import os
 
 class TestCrosECRTC(unittest.TestCase):
     def test_cros_ec_rtc_abi(self):
@@ -28,9 +28,8 @@ class TestCrosECRTC(unittest.TestCase):
                     ]
                     match += 1
                     for filename in files:
-                        self.assertEqual(
-                            os.path.exists("/sys/class/rtc/" + devname + "/" + filename), 1
-                        )
+                        p = os.path.join(dev_basepath, filename)
+                        self.assertTrue(os.path.exists(p), msg=f"{p} not found")
         except IOError as e:
-            self.skipTest("Exception occured: {0}, skipping".format(e.strerror))
-        self.assertNotEqual(match, 0)
+            self.skipTest(f"{e}")
+        self.assertNotEqual(match, 0, msg=f"No RTC device found")

--- a/cros/tests/cros_ec_rtc.py
+++ b/cros/tests/cros_ec_rtc.py
@@ -13,8 +13,10 @@ class TestCrosECRTC(unittest.TestCase):
             self.skipTest("EC_FEATURE_RTC not supported, skipping")
         match = 0
         try:
-            for devname in os.listdir("/sys/class/rtc"):
-                fd = open("/sys/class/rtc/" + devname + "/name", "r")
+            basepath = "/sys/class/rtc"
+            for devname in os.listdir(basepath):
+                dev_basepath = os.path.join(basepath, devname)
+                fd = open(os.path.join(dev_basepath, "name"), "r")
                 devtype = fd.read()
                 fd.close()
                 if devtype.startswith("cros-ec-rtc"):


### PR DESCRIPTION
Add a verbosity flag to add more error context in outputs

The current cros-ec tests as run in LAVA labs are hard to debug when they fail or when they're skipped because the error cause isn't propagated to the test output.

This commit adds an additional `--verbosity' flag that can be used to increase the amount of additional info shown in the test output:

  `--verbosity 1': basic log messages
  `--verbosity 2': basic log messages and full debug info (stacktraces)

By default, no additional error info is printed, ie. if the flag isn't used we get the same output as we always got.